### PR TITLE
Remove logs

### DIFF
--- a/packages/electron-trpc-link/src/renderer/ipcLink.ts
+++ b/packages/electron-trpc-link/src/renderer/ipcLink.ts
@@ -65,7 +65,6 @@ class IPCClient {
   }
 
   request(op: Operation, callbacks: IPCCallbacks) {
-    console.log('request', op);
     const { type, id } = op;
 
     this.#pendingRequests.set(id, {
@@ -85,7 +84,6 @@ class IPCClient {
 
       // this is the cleanup for the subscription
       if (type === 'subscription') {
-        console.log('stopping subscription');
         this.#electronTRPC.sendMessage({
           id,
           method: 'subscription.stop',
@@ -105,7 +103,6 @@ export function ipcLink<TRouter extends AnyTRPCRouter>(
   return () => {
     const client = new IPCClient();
     const transformer = getTransformer(opts?.transformer);
-    console.log('transformer', opts?.transformer);
 
     return ({ op }) => {
       return observable(observer => {


### PR DESCRIPTION
In addition to commit [67a228d](https://github.com/janwirth/electron-trpc-link/commit/67a228d50a54c7d8e1f83a38e8bb39b4dfc79469) remove remaining console logs.

Note:
The request logs might be useful in dev, I could add an optional "debug" param to the `ipcLink` function instead of deleting the logs.